### PR TITLE
Basic monitoring with Prometheus operator

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -38,6 +38,25 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/helm" {
+  version     = "2.0.3"
+  constraints = "2.0.3"
+  hashes = [
+    "h1:eUr4dHyxlcLmLja0wBgJC7t5bfHzbtACyuumKPuDrGs=",
+    "zh:154e0aa489e474e2eeb3de94be7666133faf6fd950712a640425b2bf3a81ee95",
+    "zh:16a2be6c4b61d0c5205c63816148c7ab0c8f56a75c05e8d897fa4d5cac0c029a",
+    "zh:189e47bc723f8c29bcfe2c1638d43b8148f614ea86e642f4b50b2acb4b760224",
+    "zh:3763901d3630213002cb8c70bb24c628cd29738ff6591585250ea8636264abd6",
+    "zh:4822f85e4700ea049384523d98de0ef7d83549844b13e94bbd544cec05557a9a",
+    "zh:62c5b87b09e0051bab0b712e3ad465fd53e66f9619dbe76ee23519d1087d8a05",
+    "zh:a0a6a842b11190dd1841e98bbb74961074e7ffb95984be5cc392df9f532d803e",
+    "zh:beac4e6806e77447e1018f3404a5fbf782d20d82a0d9b4a31e9bfc7d2bbecab6",
+    "zh:e1bbaa09bf4f4a91ec7606f84d2e0200a02e7b24d045e8b5daebd87d7a75b7ce",
+    "zh:ed1e05c50212d4f57435ccdd68cfb98d8395927c316df76d1dd6509566d3aeaa",
+    "zh:fdc687e16a964bb652ddb670f6832fdead25235eca551796cfed70ec07d94931",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/kubernetes" {
   version     = "2.0.2"
   constraints = "2.0.2"

--- a/environment/main.tf
+++ b/environment/main.tf
@@ -1,3 +1,10 @@
+locals {
+  host                   = azurerm_kubernetes_cluster.krony_kube.kube_config.0.host
+  client_certificate     = base64decode(azurerm_kubernetes_cluster.krony_kube.kube_config.0.client_certificate)
+  client_key             = base64decode(azurerm_kubernetes_cluster.krony_kube.kube_config.0.client_key)
+  cluster_ca_certificate = base64decode(azurerm_kubernetes_cluster.krony_kube.kube_config.0.cluster_ca_certificate)
+}
+
 provider "azurerm" {
   features {}
 }
@@ -5,10 +12,19 @@ provider "azurerm" {
 provider "azuread" {}
 
 provider "kubernetes" {
-  host                   = azurerm_kubernetes_cluster.krony_kube.kube_config.0.host
-  client_certificate     = base64decode(azurerm_kubernetes_cluster.krony_kube.kube_config.0.client_certificate)
-  client_key             = base64decode(azurerm_kubernetes_cluster.krony_kube.kube_config.0.client_key)
-  cluster_ca_certificate = base64decode(azurerm_kubernetes_cluster.krony_kube.kube_config.0.cluster_ca_certificate)
+  host                   = local.host
+  client_certificate     = local.client_certificate
+  client_key             = local.client_key
+  cluster_ca_certificate = local.cluster_ca_certificate
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = local.host
+    client_certificate     = local.client_certificate
+    client_key             = local.client_key
+    cluster_ca_certificate = local.cluster_ca_certificate
+  }
 }
 
 variable "env_name" {

--- a/environment/monitoring.tf
+++ b/environment/monitoring.tf
@@ -1,7 +1,30 @@
 resource "helm_release" "monitoring" {
-  name = "kube-prometheus-stack"
-
+  name       = "kube-prometheus-stack"
   repository = "https://prometheus-community.github.io/helm-charts"
   chart      = "kube-prometheus-stack"
   version    = "14.2.0"
+  set {
+    name  = "grafana.ingress.enabled"
+    value = "true"
+  }
+  set {
+    name  = "grafana.ingress.hosts[0]"
+    value = "admin.${var.env_name}.krony.cloud"
+  }
+  set {
+    name  = "grafana.grafana\\.ini.auth\\.proxy.enabled"
+    value = "true"
+  }
+  set {
+    name  = "grafana.grafana\\.ini.auth\\.proxy.header_name"
+    value = "X-Remote-User"
+  }
+  set {
+    name  = "grafana.ingress.annotations.traefik\\.ingress\\.kubernetes\\.io/router\\.entrypoints"
+    value = "web\\,websecure"
+  }
+  set {
+    name  = "grafana.ingress.annotations.traefik\\.ingress\\.kubernetes\\.io/router\\.middlewares"
+    value = "adminauth@file"
+  }
 }

--- a/environment/monitoring.tf
+++ b/environment/monitoring.tf
@@ -1,0 +1,7 @@
+resource "helm_release" "monitoring" {
+  name = "kube-prometheus-stack"
+
+  repository = "https://prometheus-community.github.io/helm-charts"
+  chart      = "kube-prometheus-stack"
+  version    = "14.2.0"
+}

--- a/environment/traefik.tf
+++ b/environment/traefik.tf
@@ -108,8 +108,15 @@ resource "kubernetes_config_map" "traefik" {
     "traefik.toml" = <<-EOT
       [http.middlewares]
       [http.middlewares.customerauth.basicauth]
+      removeheader = true
       users = [
         "bittrance:$2y$05$JOd.zJDDDiHhnp.gRIVHfu5LlYWda4dVduYUiefjd17mDS8xVZkru"
+      ]
+      [http.middlewares.adminauth.basicauth]
+      headerField = "X-Remote-User"
+      removeheader = true
+      users = [
+        "admin:$2y$05$JOd.zJDDDiHhnp.gRIVHfu5LlYWda4dVduYUiefjd17mDS8xVZkru"
       ]
     EOT
   }

--- a/environment/versions.tf
+++ b/environment/versions.tf
@@ -8,6 +8,10 @@ terraform {
       source = "hashicorp/azurerm"
       version = "=2.46.0"
     }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "2.0.3"
+    }
     random = {
       source = "hashicorp/random"
       version = "3.1.0"


### PR DESCRIPTION
This PR introduces the Prometheus operator and instruments Dkron and Traefik for scraping. Since this project is a learning exercise we pull in the operator through the semi-official Helm chart. See https://github.com/prometheus-operator/prometheus-operator/ for more information. We stick with Terraform for now, so we need the "alpha" version of the Terraform Kubernetes provider as it has support for arbitrary manifests, specifically CRDs. 

At the end, pretty graphs:

![image](https://user-images.githubusercontent.com/1666535/112227292-bbf9e480-8c2f-11eb-903e-eda6adf35e46.png)

