### PR TITLE
Instrumenting Traefik and Dkron to be scraped by Prometheus

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -75,6 +75,25 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/kubernetes-alpha" {
+  version     = "0.3.2"
+  constraints = "0.3.2"
+  hashes = [
+    "h1:T8AseGYyNI7PpPICFVL2Bjit0XIKVsDLssfAbN4npPM=",
+    "zh:0ad80296d13e83c308ff4389532362c69fb8c8317df6c8f2d841fed050920444",
+    "zh:1817048255f016d617a4cfcdb44d3875ca41fc7c499e6ce57b805a282e901b89",
+    "zh:2266681959871a166214a5bdf5203de63a3286b3d1d2432c03861035605b1795",
+    "zh:3385303ced06cf834645f1b8c3963850afac4c6049b193783e79e7a4e265fc53",
+    "zh:40d03e9e2030a4805740d1c3babd9e87477154f75aee65ce889cf2a814a88f87",
+    "zh:6dc79ba75c75c618c22aa378ee68b58d84055d2e95201b032781ca894443a6b5",
+    "zh:74ec1b5faab86897c003a982a45017c7d9128ec5a68a446b430f4e2e0a228d02",
+    "zh:77cea7e45c9a4fc4f378a6d4a266a4a3ab8b09e8e3451a3bce178feec8edf73c",
+    "zh:b1572257335879e815d3f8bc0122e060c9eae6fe199d9055cab4c259a23bdfe8",
+    "zh:d5a7ad66152ff3cdc9edf5d4fd174ea59d334e23230d1d3105095af605604a1d",
+    "zh:da12cd62d9d3da6a84ef6265fe3173860968d6051d7d128bcc467eeaef679eaf",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/random" {
   version     = "3.1.0"
   constraints = "3.1.0"

--- a/environment/main.tf
+++ b/environment/main.tf
@@ -18,6 +18,13 @@ provider "kubernetes" {
   cluster_ca_certificate = local.cluster_ca_certificate
 }
 
+provider "kubernetes-alpha" {
+  host                   = local.host
+  client_certificate     = local.client_certificate
+  client_key             = local.client_key
+  cluster_ca_certificate = local.cluster_ca_certificate
+}
+
 provider "helm" {
   kubernetes {
     host                   = local.host

--- a/environment/traefik.tf
+++ b/environment/traefik.tf
@@ -51,6 +51,9 @@ resource "kubernetes_service" "traefik_metrics" {
 
 resource "kubernetes_manifest" "traefik_metrics" {
   provider = kubernetes-alpha
+  depends_on = [
+    helm_release.monitoring,
+  ]
 
   manifest = {
     apiVersion = "monitoring.coreos.com/v1"

--- a/environment/traefik.tf
+++ b/environment/traefik.tf
@@ -30,6 +30,51 @@ resource "kubernetes_service" "traefik" {
   }
 }
 
+resource "kubernetes_service" "traefik_metrics" {
+  metadata {
+    name      = "traefik-metrics"
+    namespace = "kube-system"
+    labels = {
+      app = "traefik"
+    }
+  }
+  spec {
+    selector = {
+      app = "traefik"
+    }
+    port {
+      name = "metrics"
+      port = 8080
+    }
+  }
+}
+
+resource "kubernetes_manifest" "traefik_metrics" {
+  provider = kubernetes-alpha
+
+  manifest = {
+    apiVersion = "monitoring.coreos.com/v1"
+    kind       = "ServiceMonitor"
+    metadata = {
+      name      = "traefik-metrics"
+      namespace = "kube-system"
+      labels = {
+        release = "kube-prometheus-stack"
+      }
+    }
+    spec = {
+      selector = {
+        matchLabels = {
+          app = "traefik"
+        }
+      }
+      endpoints = [
+        { port = "metrics" },
+      ]
+    }
+  }
+}
+
 resource "kubernetes_daemonset" "traefik" {
   metadata {
     name      = "traefik-ingress-controller"
@@ -68,6 +113,8 @@ resource "kubernetes_daemonset" "traefik" {
             # "--certificatesresolvers.letsencrypt.acme.caserver=https://acme-staging-v02.api.letsencrypt.org/directory",
             "--certificatesresolvers.letsencrypt.acme.email=${var.letsencrypt_email}",
             "--certificatesresolvers.letsencrypt.acme.tlschallenge=true",
+            "--entrypoints.metrics.address=:8080",
+            "--metrics.prometheus.entrypoint=metrics",
             "--providers.file.filename=/config/traefik.toml",
           ]
           port {

--- a/environment/versions.tf
+++ b/environment/versions.tf
@@ -12,6 +12,10 @@ terraform {
       source  = "hashicorp/helm"
       version = "2.0.3"
     }
+    kubernetes-alpha = {
+      source  = "hashicorp/kubernetes-alpha"
+      version = "0.3.2"
+    }
     random = {
       source = "hashicorp/random"
       version = "3.1.0"

--- a/krony-app/dkron-api.tf
+++ b/krony-app/dkron-api.tf
@@ -25,6 +25,9 @@ resource "kubernetes_ingress" "dkron" {
 resource "kubernetes_service" "dkron" {
   metadata {
     name = "dkron-api"
+    labels = {
+      "app" = "dkron-api"
+    }
   }
   spec {
     selector = {
@@ -34,6 +37,35 @@ resource "kubernetes_service" "dkron" {
       name        = "http"
       port        = 80
       target_port = "http"
+    }
+  }
+}
+
+resource "kubernetes_manifest" "dkron_metrics" {
+  provider = kubernetes-alpha
+
+  manifest = {
+    apiVersion = "monitoring.coreos.com/v1"
+    kind       = "ServiceMonitor"
+    metadata = {
+      name      = "dkron-metrics"
+      namespace = "default"
+      labels = {
+        release = "kube-prometheus-stack"
+      }
+    }
+    spec = {
+      selector = {
+        matchLabels = {
+          app = "dkron-api"
+        }
+      }
+      endpoints = [
+        {
+          port = "http"
+          path = "/metrics"
+        },
+      ]
     }
   }
 }
@@ -65,6 +97,7 @@ resource "kubernetes_deployment" "dkron" {
           args = [
             "agent",
             "--server",
+            "--enable-prometheus",
             "--bootstrap-expect", "2",
             "--retry-join", "provider=k8s" # TODO: https://github.com/distribworks/dkron/issues/924
           ]

--- a/krony-app/dkron-api.tf
+++ b/krony-app/dkron-api.tf
@@ -15,6 +15,7 @@ resource "kubernetes_ingress" "dkron" {
             service_name = kubernetes_service.dkron.metadata.0.name
             service_port = "http"
           }
+          # This avoids exposing /metrics
           path = "/v1"
         }
       }

--- a/krony-app/main.tf
+++ b/krony-app/main.tf
@@ -1,3 +1,10 @@
+locals {
+  host                   = data.azurerm_kubernetes_cluster.krony_kube.kube_config.0.host
+  client_certificate     = base64decode(data.azurerm_kubernetes_cluster.krony_kube.kube_config.0.client_certificate)
+  client_key             = base64decode(data.azurerm_kubernetes_cluster.krony_kube.kube_config.0.client_key)
+  cluster_ca_certificate = base64decode(data.azurerm_kubernetes_cluster.krony_kube.kube_config.0.cluster_ca_certificate)
+}
+
 variable "env_name" {
   default = "test"
 }
@@ -7,10 +14,17 @@ provider "azurerm" {
 }
 
 provider "kubernetes" {
-  host                   = data.azurerm_kubernetes_cluster.krony_kube.kube_config.0.host
-  client_certificate     = base64decode(data.azurerm_kubernetes_cluster.krony_kube.kube_config.0.client_certificate)
-  client_key             = base64decode(data.azurerm_kubernetes_cluster.krony_kube.kube_config.0.client_key)
-  cluster_ca_certificate = base64decode(data.azurerm_kubernetes_cluster.krony_kube.kube_config.0.cluster_ca_certificate)
+  host                   = local.host
+  client_certificate     = local.client_certificate
+  client_key             = local.client_key
+  cluster_ca_certificate = local.cluster_ca_certificate
+}
+
+provider "kubernetes-alpha" {
+  host                   = local.host
+  client_certificate     = local.client_certificate
+  client_key             = local.client_key
+  cluster_ca_certificate = local.cluster_ca_certificate
 }
 
 data "azurerm_kubernetes_cluster" "krony_kube" {

--- a/krony-app/versions.tf
+++ b/krony-app/versions.tf
@@ -1,12 +1,16 @@
 terraform {
   required_providers {
     azurerm = {
-      source = "hashicorp/azurerm"
+      source  = "hashicorp/azurerm"
       version = "=2.46.0"
     }
     kubernetes = {
-      source = "hashicorp/kubernetes"
+      source  = "hashicorp/kubernetes"
       version = "2.0.2"
+    }
+    kubernetes-alpha = {
+      source  = "hashicorp/kubernetes-alpha"
+      version = "0.3.2"
     }
   }
   required_version = ">= 0.14.0"


### PR DESCRIPTION
This PR was split off from #2 in order to demonstrate that applying Helm charts separately from the parts using the terraform-kubernetes Alpha provider works. It's not really ok to do it like that, but hey this is a learning experience.